### PR TITLE
Feature/#50 jpa init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     // mysql
     implementation 'mysql:mysql-connector-java:5.1.49'
 
-    // jdbc
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    // jdbc -> jpa ( jpa 의존성 가져올 때 jdbc 도 들어 있음 )
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 
     // lombok

--- a/src/main/java/com/danggeun/DanggeunApplication.java
+++ b/src/main/java/com/danggeun/DanggeunApplication.java
@@ -2,9 +2,10 @@ package com.danggeun;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DanggeunApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/danggeun/DanggeunApplication.java
+++ b/src/main/java/com/danggeun/DanggeunApplication.java
@@ -2,10 +2,8 @@ package com.danggeun;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class DanggeunApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/danggeun/commons/config/AuditingConfig.java
+++ b/src/main/java/com/danggeun/commons/config/AuditingConfig.java
@@ -5,9 +5,11 @@ import java.util.Random;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.stereotype.Component;
 
 @Component
+@EnableJpaAuditing
 public class AuditingConfig {
 
 	@Bean

--- a/src/main/java/com/danggeun/commons/config/AuditingConfig.java
+++ b/src/main/java/com/danggeun/commons/config/AuditingConfig.java
@@ -1,0 +1,21 @@
+package com.danggeun.commons.config;
+
+import java.util.Optional;
+import java.util.Random;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditingConfig {
+
+	@Bean
+	public AuditorAware<Long> auditorProvider() {
+		// 추후 세션 사용자 정보의 값으로 변경 할 수 있도록 제공
+		// 현재는 Seed 값을 동일하게 주어 동일한 난수 패턴이 발생 하도록 하여 테스트
+		Random random = new Random(5);
+		return () -> Optional.of(random.nextLong());
+	}
+
+}

--- a/src/main/java/com/danggeun/commons/entity/BaseEntity.java
+++ b/src/main/java/com/danggeun/commons/entity/BaseEntity.java
@@ -1,16 +1,24 @@
 package com.danggeun.commons.entity;
 
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public class BaseEntity extends BaseTimeEntity {
 
+	@CreatedBy
 	@Column(updatable = false)
-	private String registeredId;
+	private Long registeredId;
 
-	private String modifiedId;
+	@LastModifiedBy
+	private Long modifiedId;
 
 }

--- a/src/main/java/com/danggeun/commons/entity/BaseEntity.java
+++ b/src/main/java/com/danggeun/commons/entity/BaseEntity.java
@@ -1,0 +1,16 @@
+package com.danggeun.commons.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public class BaseEntity extends BaseTimeEntity {
+
+	@Column(updatable = false)
+	private String registeredId;
+
+	private String modifiedId;
+
+}

--- a/src/main/java/com/danggeun/commons/entity/BaseTimeEntity.java
+++ b/src/main/java/com/danggeun/commons/entity/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.danggeun.commons.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+
+	@Column(updatable = false)
+	private LocalDateTime registeredDate;
+
+	private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/danggeun/commons/entity/BaseTimeEntity.java
+++ b/src/main/java/com/danggeun/commons/entity/BaseTimeEntity.java
@@ -2,17 +2,25 @@ package com.danggeun.commons.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public class BaseTimeEntity {
 
+	@CreatedDate
 	@Column(updatable = false)
 	private LocalDateTime registeredDate;
 
+	@LastModifiedDate
 	private LocalDateTime modifiedDate;
 
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,11 @@
 spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect
   datasource:
     driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://localhost:3306/danggeun?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
@@ -22,3 +29,7 @@ spring:
           auth: true
           starttls:
             enable: true
+
+logging:
+  level:
+    org.hibernate.sql: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   profiles:
     active: prod
+  jpa:
+    hibernate:
+      ddl-auto: none


### PR DESCRIPTION
이슈 : #50 Spring Data JPA 및 Auditing 적용

- Spring Data JPA 의존성 추가
   - implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

----
- Auditing 기능
  - auditing 적용 엔티티마다 @EntityListeners(AuditingEntityListener.class) 선언
  - auditing Base entitiy 생성 ( BaseTimeEntity, BaseEntity )
  - auditing Config 작성
  - 작성자와 수정자의 경우 현재는 Random 으로 처리